### PR TITLE
Fix: Add Docker-in-Docker feature to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
     "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18", // Uses Node.js 18
 
     "features": {
-        "ghcr.io/devcontainers/features/git:1": {} // Ensures Git is available
+        "ghcr.io/devcontainers/features/git:1": {}, // Ensures Git is available
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
     },
 
     // Forward the application port from the container to the host.


### PR DESCRIPTION
The Docker CLI was not available within the VS Code development container, causing `docker build` commands to fail with "docker: not found".

This change adds the "ghcr.io/devcontainers/features/docker-in-docker:2" feature to the `.devcontainer/devcontainer.json` configuration. This installs Docker within the dev container, allowing Docker commands to be executed successfully.

You will need to rebuild your dev container for this change to take effect.