### PR TITLE
Fix: Correct EJS tag in vim modelines

### DIFF
--- a/views/admin_settings.ejs
+++ b/views/admin_settings.ejs
@@ -122,4 +122,4 @@
 </div>
 
 <%- include('partials/_footer') %>
-<%- /* vim: set ft=html : */ -%>
+<%# /* vim: set ft=html : */ %>

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -94,4 +94,4 @@
 </div>
 
 <%- include('partials/_footer') %>
-<%- /* vim: set ft=html : */ -%>
+<%# /* vim: set ft=html : */ %>


### PR DESCRIPTION
Corrected the EJS tag in vim modelines in `views/admin_settings.ejs` and `views/setup.ejs`. The unescaped output tag `<%-` was incorrectly used for comments, causing an "Error: Could not find matching close tag for '<%-'". Changed `<%-` to the EJS comment tag `<%#` to resolve the parsing error.