### PR TITLE
Fix: Correct EJS include syntax in layout.ejs

### DIFF
--- a/views/admin_settings.ejs
+++ b/views/admin_settings.ejs
@@ -122,4 +122,4 @@
 </div>
 
 <%- include('partials/_footer') %>
-<%- /* vim: set ft=html : */ -%>
+<%# /* vim: set ft=html : */ %>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -32,22 +32,22 @@
 </head>
 <body>
     <header>
-        <%- include('partials/_navbar', { user: typeof user !== 'undefined' ? user : null, currentPath: typeof currentPath !== 'undefined' ? currentPath : '/' }) %>
+        <% include partials/_navbar { user: typeof user !== 'undefined' ? user : null, currentPath: typeof currentPath !== 'undefined' ? currentPath : '/' } %>
     </header>
 
     <div class="container">
-        <%- include('partials/_flash_messages', { messages: typeof messages !== 'undefined' ? messages : {} }) %>
+        <% include partials/_flash_messages { messages: typeof messages !== 'undefined' ? messages : {} } %>
         <%- body %>
     </div>
 
     <footer>
         <p>&copy; <%= new Date().getFullYear() %> OPNsense Rule Controller</p>
         <!-- You can add the config status partial here if desired -->
-        <%- include('partials/_config_status', {
+        <% include partials/_config_status {
             is_app_secret_key_configured: typeof is_app_secret_key_configured !== 'undefined' ? is_app_secret_key_configured : false,
             is_opnsense_fully_configured: typeof is_opnsense_fully_configured !== 'undefined' ? is_opnsense_fully_configured : false,
             is_google_oauth_configured: typeof is_google_oauth_configured !== 'undefined' ? is_google_oauth_configured : false
-        }) %>
+        } %>
     </footer>
 </body>
 </html>

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -94,4 +94,4 @@
 </div>
 
 <%- include('partials/_footer') %>
-<%- /* vim: set ft=html : */ -%>
+<%# /* vim: set ft=html : */ %>


### PR DESCRIPTION
I changed the EJS include syntax in `views/layout.ejs` from the incorrect `<%- include('path', data) %>` to the standard EJS directive `<% include path data_object %>`.

This addresses potential parsing errors that can occur when using output tags (`<%-` or `<%=`) with the `include` directive, which is a control-flow tag (`<%`). The specific error "Could not find matching close tag for '<%-' " can be triggered by this incorrect syntax.