### PR TITLE
Fix: Correct EJS include syntax for layout includes

### DIFF
--- a/views/admin_invitations.ejs
+++ b/views/admin_invitations.ejs
@@ -20,7 +20,7 @@
     </style>
 </head>
 <body>
-    <%- include('partials/navbar', { user: user }) %> <!-- Assuming a navbar partial -->
+    <% include partials/navbar { user: user } %> <!-- Assuming a navbar partial -->
 
     <h1>Admin: Manage Invitation Codes</h1>
 

--- a/views/admin_settings.ejs
+++ b/views/admin_settings.ejs
@@ -1,4 +1,4 @@
-<%- include('partials/_navbar', { currentPath: '/admin/settings' }) %>
+<% include partials/_navbar { currentPath: '/admin/settings' } %>
 
 <div class="container mt-4">
     <div class="row">
@@ -8,7 +8,7 @@
                 Manage core application settings here. Be cautious when changing these values, especially secrets.
             </p>
 
-            <%- include('partials/_flash_messages') %>
+            <% include partials/_flash_messages {} %>
             <% if (typeof queryMessages !== 'undefined' && queryMessages.error) { %>
                 <div class="alert alert-danger"><%= queryMessages.error %></div>
             <% } %>
@@ -121,5 +121,5 @@
     </div>
 </div>
 
-<%- include('partials/_footer') %>
-<%- /* vim: set ft=html : */ -%>
+<% include partials/_footer {} %>
+<%# /* vim: set ft=html : */ %>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,4 +1,4 @@
-<%- include('layout', { 
+<% include layout { 
     pageTitle: 'Welcome - OPNsense Rule Controller', 
     user: typeof user !== 'undefined' ? user : null, 
     currentPath: '/',
@@ -47,4 +47,4 @@
             <% } %>
         </div>
     `
-}) %>
+} %>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -32,22 +32,22 @@
 </head>
 <body>
     <header>
-        <%- include('partials/_navbar', { user: typeof user !== 'undefined' ? user : null, currentPath: typeof currentPath !== 'undefined' ? currentPath : '/' }) %>
+        <% include partials/_navbar { user: typeof user !== 'undefined' ? user : null, currentPath: typeof currentPath !== 'undefined' ? currentPath : '/' } %>
     </header>
 
     <div class="container">
-        <%- include('partials/_flash_messages', { messages: typeof messages !== 'undefined' ? messages : {} }) %>
+        <% include partials/_flash_messages { messages: typeof messages !== 'undefined' ? messages : {} } %>
         <%- body %>
     </div>
 
     <footer>
         <p>&copy; <%= new Date().getFullYear() %> OPNsense Rule Controller</p>
         <!-- You can add the config status partial here if desired -->
-        <%- include('partials/_config_status', {
+        <% include partials/_config_status {
             is_app_secret_key_configured: typeof is_app_secret_key_configured !== 'undefined' ? is_app_secret_key_configured : false,
             is_opnsense_fully_configured: typeof is_opnsense_fully_configured !== 'undefined' ? is_opnsense_fully_configured : false,
             is_google_oauth_configured: typeof is_google_oauth_configured !== 'undefined' ? is_google_oauth_configured : false
-        }) %>
+        } %>
     </footer>
 </body>
 </html>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,4 +1,4 @@
-<%- include('layout', { 
+<% include layout { 
     pageTitle: 'Login - OPNsense Rule Controller', 
     user: typeof user !== 'undefined' ? user : null, 
     currentPath: '/auth/login', // Updated currentPath
@@ -59,4 +59,4 @@
             .auth-switch-link { margin-top: 20px; }
         </style>
     `
-}) %>
+} %>

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -1,4 +1,4 @@
-<%- include('layout', { 
+<% include layout { 
     pageTitle: 'Register - OPNsense Rule Controller', 
     user: typeof user !== 'undefined' ? user : null, 
     currentPath: '/auth/register',
@@ -42,4 +42,4 @@
             .auth-switch-link { margin-top: 20px; }
         </style>
     `
-}) %>
+} %>

--- a/views/rules.ejs
+++ b/views/rules.ejs
@@ -1,4 +1,4 @@
-<%- include('layout', { 
+<% include layout { 
     pageTitle: 'Manage Firewall Rules', 
     user: typeof user !== 'undefined' ? user : null, 
     currentPath: '/rules',
@@ -15,7 +15,7 @@
                 </p>
             <% } %>
 
-            <%- /* Section for Flash Messages - if not handled globally in layout by _flash_messages.ejs already */ %>
+            <%# /* Section for Flash Messages - if not handled globally in layout by _flash_messages.ejs already */ %>
             <% if (locals.flash_error) { %><div class="alert alert-danger"><%= flash_error %></div><% } %>
             <% if (locals.flash_success) { %><div class="alert alert-success"><%= flash_success %></div><% } %>
 
@@ -173,4 +173,4 @@
             .status-timer { color: #007bff; }
         </style>
     `
-}) %>
+} %>

--- a/views/schedules.ejs
+++ b/views/schedules.ejs
@@ -1,4 +1,4 @@
-<%- include('layout', { 
+<% include layout { 
     pageTitle: pageTitle || 'Manage Schedules', 
     user: user, 
     currentPath: currentPath,
@@ -109,4 +109,4 @@
             </section>
         </div>
     `
-}) %>
+} %>

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -1,4 +1,4 @@
-<%- include('partials/_navbar', { currentPath: '/setup' }) %>
+<% include partials/_navbar { currentPath: '/setup' } %>
 
 <div class="container mt-4">
     <h1>Initial Application Setup</h1>
@@ -8,7 +8,7 @@
         but this setup process will help you initialize them.
     </p>
 
-    <%- include('partials/_flash_messages') %>
+    <% include partials/_flash_messages {} %>
     <% if (typeof queryMessages !== 'undefined' && queryMessages.error) { %>
         <div class="alert alert-danger"><%= queryMessages.error %></div>
     <% } %>
@@ -93,5 +93,5 @@
     </form>
 </div>
 
-<%- include('partials/_footer') %>
-<%- /* vim: set ft=html : */ -%>
+<% include partials/_footer {} %>
+<%# /* vim: set ft=html : */ %>


### PR DESCRIPTION
Changed the EJS include syntax for main layout inclusion from `<%- include('layout', data) %>` to `<% include layout data %>` in the following files:
- views/index.ejs
- views/login.ejs
- views/register.ejs
- views/rules.ejs
- views/schedules.ejs

This change ensures that the EJS `include` directive, which is a control-flow tag, is used with the correct scriptlet tag `<% ... %>` instead of an output tag (`<%-` or `<%=`). This is intended to resolve persistent EJS parsing errors like "Could not find matching close tag for '<%-'".

This also includes prior corrections to:
- Vim modelines in `admin_settings.ejs` and `setup.ejs`.
- Comment syntax in `rules.ejs`.
- Partial include syntax in `admin_invitations.ejs`, `admin_settings.ejs`, and `setup.ejs`.