### PR TITLE
Refactor: Move EJS content out of body template literals

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -3,8 +3,9 @@
     user: typeof user !== 'undefined' ? user : null, 
     currentPath: '/',
     messages: typeof messages !== 'undefined' ? messages : {},
-    queryMessages: typeof queryMessages !== 'undefined' ? queryMessages : {},
-    body: `
+    queryMessages: typeof queryMessages !== 'undefined' ? queryMessages : {}
+} %>
+
         <div class="index-container" style="text-align: center; padding: 40px 20px;">
             <h1>Welcome to the OPNsense Rule Controller</h1>
 
@@ -46,5 +47,3 @@
                 <% } %>
             <% } %>
         </div>
-    `
-} %>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -3,12 +3,13 @@
     user: typeof user !== 'undefined' ? user : null, 
     currentPath: '/auth/login', // Updated currentPath
     // sessionFlashMessages is available globally via app.locals or context processor in app.js
-    body: `
+} %>
+
         <div class="auth-container">
             <h2>Login</h2>
             <p>Please log in to manage your OPNsense firewall rules.</p>
 
-            <%- include('partials/_flash_messages') %> <% /* Flash messages will be rendered here if any */ %>
+            <% include('partials/_flash_messages') %> <% /* Flash messages will be rendered here if any */ %>
 
             <form action="/auth/login" method="POST" class="auth-form">
                 <div class="form-group">
@@ -39,7 +40,7 @@
             <hr style="margin-top: 30px; margin-bottom: 20px;">
             <h4>Configuration Status Overview:</h4>
             <p><small>This section is for diagnostic purposes.</small></p>
-            <%- include('partials/_config_status', {
+            <% include('partials/_config_status', {
                 is_app_secret_key_configured: typeof is_app_secret_key_configured !== 'undefined' ? is_app_secret_key_configured : false,
                 is_opnsense_fully_configured: typeof is_opnsense_fully_configured !== 'undefined' ? is_opnsense_fully_configured : false,
                 is_google_oauth_configured: typeof is_google_oauth_configured !== 'undefined' ? is_google_oauth_configured : false
@@ -58,5 +59,3 @@
             .or-separator::before, .or-separator::after { content: ''; flex: 1; border-bottom: 1px solid #ccc; }
             .auth-switch-link { margin-top: 20px; }
         </style>
-    `
-} %>

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -1,13 +1,14 @@
 <% include layout { 
     pageTitle: 'Register - OPNsense Rule Controller', 
     user: typeof user !== 'undefined' ? user : null, 
-    currentPath: '/auth/register',
-    body: `
+    currentPath: '/auth/register'
+} %>
+
         <div class="auth-container">
             <h2>Register</h2>
             <p>Create a new account.</p>
 
-            <%- include('partials/_flash_messages') %>
+            <% include('partials/_flash_messages') %>
 
             <form action="/auth/register" method="POST" class="auth-form">
                 <div class="form-group">
@@ -41,5 +42,3 @@
             .auth-form button { width: 100%; padding: 12px; font-size: 1.1em; }
             .auth-switch-link { margin-top: 20px; }
         </style>
-    `
-} %>

--- a/views/rules.ejs
+++ b/views/rules.ejs
@@ -3,8 +3,9 @@
     user: typeof user !== 'undefined' ? user : null, 
     currentPath: '/rules',
     messages: typeof messages !== 'undefined' ? messages : {},
-    queryMessages: typeof queryMessages !== 'undefined' ? queryMessages : {},
-    body: `
+    queryMessages: typeof queryMessages !== 'undefined' ? queryMessages : {}
+} %>
+
         <div class="rules-container">
             <h2>OPNsense Firewall Rule Management</h2>
 
@@ -172,5 +173,3 @@
             .status-error { color: #b30000; font-weight: bold; }
             .status-timer { color: #007bff; }
         </style>
-    `
-} %>

--- a/views/schedules.ejs
+++ b/views/schedules.ejs
@@ -3,8 +3,9 @@
     user: user, 
     currentPath: currentPath,
     messages: messages, // Assuming messages are passed from the route
-    queryMessages: queryMessages, // Assuming queryMessages are passed
-    body: `
+    queryMessages: queryMessages // Assuming queryMessages are passed
+} %>
+
         <div class="schedules-container">
             <h2>Rule Schedules</h2>
 
@@ -108,5 +109,3 @@
                 <% } %>
             </section>
         </div>
-    `
-} %>


### PR DESCRIPTION
I refactored views/index.ejs, views/login.ejs, views/register.ejs, views/rules.ejs, and views/schedules.ejs. I changed the structure from passing content via `body: \`...\` in `<% include layout ... %>` to placing content directly in the EJS files. This ensures that EJS tags within these files are correctly parsed by the EJS engine, resolving potential "Could not find matching close tag" errors and similar parsing issues related to EJS tags embedded in JavaScript template strings. I corrected `<%- include(...) %>` to `<% include(...) %>` for partials within these files during refactoring where necessary.