### PR TITLE
Fix: Correct EJS include syntax and update route handlers

### DIFF
--- a/controllers/settingsController.js
+++ b/controllers/settingsController.js
@@ -37,7 +37,7 @@ exports.getSetupPage = (req, res) => {
         };
         
         res.render('setup', { 
-            title: 'Initial Application Setup',
+            pageTitle: 'Application Setup', // Changed title to pageTitle and updated value
             settings: initialSettings, 
             formData: formData        
         });
@@ -158,7 +158,7 @@ exports.getAdminSettingsPage = (req, res) => {
         }
 
         res.render('admin_settings', {
-            title: 'Admin - Application Settings',
+            pageTitle: 'Admin - Settings', // Changed title to pageTitle and updated value
             settings: templateSettings, 
             formData: formData 
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "bcrypt": "^6.0.0",
         "better-sqlite3": "^11.10.0",
         "dotenv": "^16.5.0",
-        "ejs": "^3.1.9",
+        "ejs": "^3.1.10",
         "express": "^5.1.0",
         "express-session": "^1.18.1",
         "node-cron": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^11.10.0",
     "dotenv": "^16.5.0",
-    "ejs": "^3.1.9",
+    "ejs": "^3.1.10",
     "express": "^5.1.0",
     "express-session": "^1.18.1",
     "node-cron": "^4.0.7",

--- a/routes/adminRoutes.js
+++ b/routes/adminRoutes.js
@@ -17,8 +17,8 @@ router.get('/invitations', async (req, res) => {
         // app.set('views', path.join(__dirname, 'views'));
         res.render('admin_invitations', { 
             invitations: invitations,
-            user: req.user, // Pass user for layout/nav if needed
-            pageTitle: "Admin - Manage Invitations" 
+            // user: req.user, // user is now in res.locals
+            pageTitle: "Admin - Invitations" 
         });
     } catch (error) {
         console.error("Error rendering admin invitations page:", error);

--- a/routes/scheduleRoutes.js
+++ b/routes/scheduleRoutes.js
@@ -17,13 +17,13 @@ router.get('/', async (req, res) => {
         // const messages = req.flash(); // Example: { error: ['Msg 1'], success: ['Msg 2'] }
 
         res.render('schedules', {
-            pageTitle: 'Manage Schedules',
-            user: req.user,
+            pageTitle: 'Manage Schedules', // Already correct
+            // user: req.user, // now in res.locals
             schedules: schedules,
             managedRules: managedRules, // For the "Add Schedule" form dropdown
-            currentPath: '/schedules',
-            messages: {} // Replace with actual flash messages if implemented
-            // queryMessages: { error: req.query.error, success: req.query.success } // If using query params
+            // currentPath: '/schedules', // now in res.locals
+            // messages: {} // sessionFlashMessages is global
+            // queryMessages: { error: req.query.error, success: req.query.success } // queryMessages is global
         });
     } catch (error) {
         console.error("Error rendering schedules page:", error);

--- a/routes/uiRoutes.js
+++ b/routes/uiRoutes.js
@@ -39,18 +39,20 @@ router.get('/', (req, res) => {
         //     // For now, let's assume authService handles clearing it post-registration.
         // }
         return res.render('index', { 
-            user: req.user, 
+            pageTitle: 'Welcome - OPNsense Rule Controller', // Added pageTitle
+            // user: req.user, // now in res.locals
             invitationCode: req.session.invitationCode, // Pass to template if needed
-            queryMessages,
-            currentPath: '/'
+            // queryMessages, // now in res.locals
+            // currentPath: '/' // now in res.locals
         });
     } else {
         // Not authenticated
         return res.render('index', { 
-            user: null, 
+            pageTitle: 'Welcome - OPNsense Rule Controller', // Added pageTitle
+            // user: null, // now in res.locals
             invitationCode: req.session.invitationCode,
-            queryMessages,
-            currentPath: '/'
+            // queryMessages, // now in res.locals
+            // currentPath: '/' // now in res.locals
         });
     }
 });
@@ -64,12 +66,13 @@ router.get('/login', (req, res) => {
     // Pass any specific messages for the login page, e.g., from auth failures
     // req.flash() messages are not set up yet, so using query params for now.
     res.render('login', { 
-        user: null, 
-        currentPath: '/login',
-        messages: req.session.messages || [], // Placeholder for connect-flash
-        queryMessages // Pass query-based messages
+        pageTitle: 'Login - OPNsense Rule Controller', // Added pageTitle
+        // user: null, // now in res.locals
+        // currentPath: '/login', // now in res.locals
+        // messages: req.session.messages || [], // Placeholder for connect-flash; sessionFlashMessages is global
+        // queryMessages // Pass query-based messages; queryMessages is global
     });
-    req.session.messages = []; // Clear messages after displaying
+    // req.session.messages = []; // Clear messages after displaying // sessionFlashMessages handles this
 });
 
 
@@ -140,12 +143,13 @@ router.get('/rules', isAuthenticated, async (req, res) => {
         }
         
         res.render('rules', {
-            user: req.user,
+            pageTitle: 'Manage Firewall Rules', // Added pageTitle
+            // user: req.user, // now in res.locals
             managedRules: managedRulesWithStatus,
             fetchedOpnsenseRules: fetchedOpnsenseRules, // From session or null
             vlanFilterValue: vlanFilterValue, // For the input field
-            currentPath: '/rules',
-            messages: req.flash ? req.flash() : {} // For connect-flash if used
+            // currentPath: '/rules', // now in res.locals
+            // messages: req.flash ? req.flash() : {} // For connect-flash if used; sessionFlashMessages is global
         });
     } catch (error) {
         console.error("Error in GET /rules:", error);

--- a/routes/userAuthRoutes.js
+++ b/routes/userAuthRoutes.js
@@ -10,7 +10,7 @@ router.get('/login', (req, res) => {
     // If not, it needs to be explicitly fetched or passed.
     // For now, assume it's available or views handle its absence.
     res.render('login', { 
-        pageTitle: 'Login',
+        pageTitle: 'Login - OPNsense Rule Controller',
         // Pass any necessary variables for the login.ejs template,
         // like is_google_oauth_configured, which is used in the template.
         // These are typically set globally in app.js for all views.
@@ -21,7 +21,7 @@ router.get('/login', (req, res) => {
 // GET /register - Display registration page
 router.get('/register', (req, res) => {
     res.render('register', { 
-        pageTitle: 'Register',
+        pageTitle: 'Register - OPNsense Rule Controller',
         // Pass any necessary variables for the register.ejs template
         // For example, if you want to pass back input values on validation error:
         // input: req.session.input || {} // Clear after use if needed

--- a/tests/views.test.js
+++ b/tests/views.test.js
@@ -1,0 +1,35 @@
+const ejs = require('ejs');
+const fs = require('fs');
+const path = require('path');
+
+// List of EJS files to test for compilability
+const filesToTest = [
+    'views/login.ejs',
+    'views/admin_invitations.ejs',
+    'views/admin_settings.ejs',
+    'views/index.ejs',
+    'views/layout.ejs',
+    'views/register.ejs',
+    'views/rules.ejs',
+    'views/schedules.ejs',
+    'views/setup.ejs',
+    'views/partials/_navbar.ejs',
+    'views/partials/_flash_messages.ejs',
+    'views/partials/_config_status.ejs',
+    'views/partials/_footer.ejs'
+];
+
+describe('EJS Template Compilation Tests', () => {
+    filesToTest.forEach(filePath => {
+        it(`should compile ${filePath} without syntax errors`, () => {
+            const templatePath = path.join(__dirname, '..', filePath); // Adjust path to be relative to project root
+            const templateContent = fs.readFileSync(templatePath, 'utf-8');
+            
+            // Attempt to compile the template
+            // If there's a syntax error, ejs.compile will throw an exception
+            expect(() => {
+                ejs.compile(templateContent, { client: true, filename: templatePath });
+            }).not.toThrow();
+        });
+    });
+});

--- a/views/admin_invitations.ejs
+++ b/views/admin_invitations.ejs
@@ -20,7 +20,7 @@
     </style>
 </head>
 <body>
-    <% include partials/navbar { user: user } %> <!-- Assuming a navbar partial -->
+    <%- include('partials/_navbar') %> <!-- Assuming a navbar partial -->
 
     <h1>Admin: Manage Invitation Codes</h1>
 

--- a/views/admin_settings.ejs
+++ b/views/admin_settings.ejs
@@ -1,4 +1,4 @@
-<% include partials/_navbar { currentPath: '/admin/settings' } %>
+<%- include('partials/_navbar') %>
 
 <div class="container mt-4">
     <div class="row">
@@ -8,7 +8,7 @@
                 Manage core application settings here. Be cautious when changing these values, especially secrets.
             </p>
 
-            <% include partials/_flash_messages {} %>
+            <%- include('partials/_flash_messages') %>
             <% if (typeof queryMessages !== 'undefined' && queryMessages.error) { %>
                 <div class="alert alert-danger"><%= queryMessages.error %></div>
             <% } %>
@@ -121,5 +121,5 @@
     </div>
 </div>
 
-<% include partials/_footer {} %>
+<%- include('partials/_footer') %>
 <%# /* vim: set ft=html : */ %>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,10 +1,4 @@
-<% include layout { 
-    pageTitle: 'Welcome - OPNsense Rule Controller', 
-    user: typeof user !== 'undefined' ? user : null, 
-    currentPath: '/',
-    messages: typeof messages !== 'undefined' ? messages : {},
-    queryMessages: typeof queryMessages !== 'undefined' ? queryMessages : {}
-} %>
+<%- include('layout') %>
 
         <div class="index-container" style="text-align: center; padding: 40px 20px;">
             <h1>Welcome to the OPNsense Rule Controller</h1>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -32,22 +32,18 @@
 </head>
 <body>
     <header>
-        <% include partials/_navbar { user: typeof user !== 'undefined' ? user : null, currentPath: typeof currentPath !== 'undefined' ? currentPath : '/' } %>
+        <%- include('partials/_navbar') %>
     </header>
 
     <div class="container">
-        <% include partials/_flash_messages { messages: typeof messages !== 'undefined' ? messages : {} } %>
+        <%- include('partials/_flash_messages') %>
         <%- body %>
     </div>
 
     <footer>
         <p>&copy; <%= new Date().getFullYear() %> OPNsense Rule Controller</p>
         <!-- You can add the config status partial here if desired -->
-        <% include partials/_config_status {
-            is_app_secret_key_configured: typeof is_app_secret_key_configured !== 'undefined' ? is_app_secret_key_configured : false,
-            is_opnsense_fully_configured: typeof is_opnsense_fully_configured !== 'undefined' ? is_opnsense_fully_configured : false,
-            is_google_oauth_configured: typeof is_google_oauth_configured !== 'undefined' ? is_google_oauth_configured : false
-        } %>
+        <%- include('partials/_config_status') %>
     </footer>
 </body>
 </html>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,9 +1,4 @@
-<% include layout { 
-    pageTitle: 'Login - OPNsense Rule Controller', 
-    user: typeof user !== 'undefined' ? user : null, 
-    currentPath: '/auth/login', // Updated currentPath
-    // sessionFlashMessages is available globally via app.locals or context processor in app.js
-} %>
+<%- include('layout') %>
 
         <div class="auth-container">
             <h2>Login</h2>
@@ -40,11 +35,7 @@
             <hr style="margin-top: 30px; margin-bottom: 20px;">
             <h4>Configuration Status Overview:</h4>
             <p><small>This section is for diagnostic purposes.</small></p>
-            <% include('partials/_config_status', {
-                is_app_secret_key_configured: typeof is_app_secret_key_configured !== 'undefined' ? is_app_secret_key_configured : false,
-                is_opnsense_fully_configured: typeof is_opnsense_fully_configured !== 'undefined' ? is_opnsense_fully_configured : false,
-                is_google_oauth_configured: typeof is_google_oauth_configured !== 'undefined' ? is_google_oauth_configured : false
-            }) %>
+            <%- include('partials/_config_status') %>
         </div>
         <style>
             .auth-container { text-align: center; max-width: 400px; margin: 30px auto; padding: 20px; border: 1px solid #ddd; border-radius: 8px; background-color: #fff; box-shadow: 0 0 10px rgba(0,0,0,0.05); }

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -1,8 +1,4 @@
-<% include layout { 
-    pageTitle: 'Register - OPNsense Rule Controller', 
-    user: typeof user !== 'undefined' ? user : null, 
-    currentPath: '/auth/register'
-} %>
+<%- include('layout') %>
 
         <div class="auth-container">
             <h2>Register</h2>

--- a/views/rules.ejs
+++ b/views/rules.ejs
@@ -1,10 +1,4 @@
-<% include layout { 
-    pageTitle: 'Manage Firewall Rules', 
-    user: typeof user !== 'undefined' ? user : null, 
-    currentPath: '/rules',
-    messages: typeof messages !== 'undefined' ? messages : {},
-    queryMessages: typeof queryMessages !== 'undefined' ? queryMessages : {}
-} %>
+<%- include('layout') %>
 
         <div class="rules-container">
             <h2>OPNsense Firewall Rule Management</h2>

--- a/views/schedules.ejs
+++ b/views/schedules.ejs
@@ -1,10 +1,4 @@
-<% include layout { 
-    pageTitle: pageTitle || 'Manage Schedules', 
-    user: user, 
-    currentPath: currentPath,
-    messages: messages, // Assuming messages are passed from the route
-    queryMessages: queryMessages // Assuming queryMessages are passed
-} %>
+<%- include('layout') %>
 
         <div class="schedules-container">
             <h2>Rule Schedules</h2>

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -1,4 +1,4 @@
-<% include partials/_navbar { currentPath: '/setup' } %>
+<%- include('partials/_navbar') %>
 
 <div class="container mt-4">
     <h1>Initial Application Setup</h1>
@@ -8,7 +8,7 @@
         but this setup process will help you initialize them.
     </p>
 
-    <% include partials/_flash_messages {} %>
+    <%- include('partials/_flash_messages') %>
     <% if (typeof queryMessages !== 'undefined' && queryMessages.error) { %>
         <div class="alert alert-danger"><%= queryMessages.error %></div>
     <% } %>
@@ -93,5 +93,5 @@
     </form>
 </div>
 
-<% include partials/_footer {} %>
+<%- include('partials/_footer') %>
 <%# /* vim: set ft=html : */ %>


### PR DESCRIPTION
This commit resolves a `SyntaxError: Unexpected identifier` in EJS templates caused by using non-standard object parameters with the `include` directive.

Changes include:

- Modified all EJS files in `views/` to use the standard `<%- include('path') %>` syntax, removing object parameters from includes. Affected files: `login.ejs`, `admin_invitations.ejs`, `admin_settings.ejs`, `index.ejs`, `layout.ejs`, `register.ejs`, `rules.ejs`, `schedules.ejs`, `setup.ejs`.
- Updated corresponding route handlers and controllers to ensure all necessary data (especially `pageTitle`) is passed to `res.render()`.
- Leveraged existing global middleware in `app.js` which provides `user`, `currentPath`, and various configuration flags (`is_app_secret_key_configured`, `is_opnsense_fully_configured`, `is_google_oauth_configured`), `queryMessages`, and `sessionFlashMessages` to all templates, reducing redundant data passing in routes.
- Added a new test suite (`tests/views.test.js`) to verify that all modified EJS templates and key partials can be compiled by EJS without syntax errors.

These changes ensure templates are parsed correctly, adhere to EJS standards, and maintain necessary data flow for rendering.