### PR TITLE
Fix: Correct EJS layout rendering and update route handlers

### DIFF
--- a/controllers/settingsController.js
+++ b/controllers/settingsController.js
@@ -1,3 +1,5 @@
+const ejs = require('ejs'); // Added EJS
+const path = require('path'); // Added Path
 const { getSetting, setSetting, getAllSettings } = require('../db/database');
 
 // Helper function for URL validation
@@ -17,34 +19,40 @@ function isValidHttpUrl(string) {
 // We use it here to determine if a DB-retrieved value is effectively "not set".
 const DEFAULT_PLACEHOLDER = "!!MUST_BE_SET_IN_ENVIRONMENT!!";
 
-exports.getSetupPage = (req, res) => {
+exports.getSetupPage = async (req, res, next) => { // Made async, added next
     try {
         const setupComplete = getSetting('initial_setup_complete') === 'true';
         if (setupComplete) {
             return res.redirect('/');
         }
 
-        const formData = req.session.setupFormPrefill || {};
-        delete req.session.setupFormPrefill;
-
-        // Initial settings from config/env (these are defaults before setup is complete)
-        const initialSettings = {
-            APP_BASE_URL: req.app.config.APP_BASE_URL !== DEFAULT_PLACEHOLDER ? req.app.config.APP_BASE_URL : (process.env.APP_BASE_URL || ''),
-            SESSION_SECRET: req.app.config.SESSION_SECRET, // Updated key
-            OPNSENSE_BASE_URL: req.app.config.OPNSENSE_BASE_URL !== DEFAULT_PLACEHOLDER ? req.app.config.OPNSENSE_BASE_URL : (process.env.OPNSENSE_BASE_URL || ''),
-            OPNSENSE_API_KEY: req.app.config.OPNSENSE_API_KEY !== DEFAULT_PLACEHOLDER ? req.app.config.OPNSENSE_API_KEY : (process.env.OPNSENSE_API_KEY || ''),
-            GOOGLE_CLIENT_ID: req.app.config.GOOGLE_CLIENT_ID !== DEFAULT_PLACEHOLDER ? req.app.config.GOOGLE_CLIENT_ID : (process.env.GOOGLE_CLIENT_ID || ''),
+        const pageData = {
+            pageTitle: 'Application Setup',
+            settings: { // Initial settings from config/env (these are defaults before setup is complete)
+                APP_BASE_URL: req.app.config.APP_BASE_URL !== DEFAULT_PLACEHOLDER ? req.app.config.APP_BASE_URL : (process.env.APP_BASE_URL || ''),
+                SESSION_SECRET: req.app.config.SESSION_SECRET,
+                OPNSENSE_BASE_URL: req.app.config.OPNSENSE_BASE_URL !== DEFAULT_PLACEHOLDER ? req.app.config.OPNSENSE_BASE_URL : (process.env.OPNSENSE_BASE_URL || ''),
+                OPNSENSE_API_KEY: req.app.config.OPNSENSE_API_KEY !== DEFAULT_PLACEHOLDER ? req.app.config.OPNSENSE_API_KEY : (process.env.OPNSENSE_API_KEY || ''),
+                GOOGLE_CLIENT_ID: req.app.config.GOOGLE_CLIENT_ID !== DEFAULT_PLACEHOLDER ? req.app.config.GOOGLE_CLIENT_ID : (process.env.GOOGLE_CLIENT_ID || ''),
+            },
+            formData: req.session.setupFormPrefill || {}
         };
+        if (req.session.setupFormPrefill) delete req.session.setupFormPrefill;
         
-        res.render('setup', { 
-            title: 'Initial Application Setup',
-            settings: initialSettings, 
-            formData: formData        
+        const contentHtml = await ejs.renderFile(
+            path.join(req.app.get('views'), 'setup.ejs'),
+            { ...pageData, ...res.locals },
+            { async: true }
+        );
+        res.render('layout', {
+            pageTitle: pageData.pageTitle,
+            body: contentHtml
         });
-    } catch (error) {
-        console.error("Error in getSetupPage:", error);
-        req.session.flashMessages = { error: "Error loading setup page. Please check logs." };
-        res.redirect('/login'); // Redirect to login or a generic error page
+    } catch (err) { // Changed error variable name for consistency
+        console.error(`Error in getSetupPage or rendering setup.ejs/layout:`, err);
+        // req.session.flashMessages = { error: "Error loading setup page. Please check logs." };
+        // res.redirect('/login'); // Redirecting here might be problematic.
+        next(err); // Propagate error
     }
 };
 
@@ -157,15 +165,26 @@ exports.getAdminSettingsPage = (req, res) => {
             templateSettings.SESSION_SECRET_STATUS_MESSAGE = "Not Set or Using Default Placeholder! This is a security risk. Set via Environment.";
         }
 
-        res.render('admin_settings', {
-            title: 'Admin - Application Settings',
-            settings: templateSettings, 
-            formData: formData 
+        const pageData = {
+            pageTitle: 'Admin - Settings',
+            settings: templateSettings,
+            formData: formData
+        };
+
+        const contentHtml = await ejs.renderFile(
+            path.join(req.app.get('views'), 'admin_settings.ejs'),
+            { ...pageData, ...res.locals },
+            { async: true }
+        );
+        res.render('layout', {
+            pageTitle: pageData.pageTitle,
+            body: contentHtml
         });
-    } catch (error) {
-        console.error("Error in getAdminSettingsPage:", error);
-        req.session.flashMessages = { error: "Error loading admin settings page." };
-        res.redirect('/admin');
+    } catch (err) { // Changed error variable name for consistency
+        console.error(`Error in getAdminSettingsPage or rendering admin_settings.ejs/layout:`, err);
+        // req.session.flashMessages = { error: "Error loading admin settings page." };
+        // res.redirect('/admin'); // Redirecting here might be problematic.
+        next(err); // Propagate error
     }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "bcrypt": "^6.0.0",
         "better-sqlite3": "^11.10.0",
         "dotenv": "^16.5.0",
-        "ejs": "^3.1.9",
+        "ejs": "^3.1.10",
         "express": "^5.1.0",
         "express-session": "^1.18.1",
         "node-cron": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^11.10.0",
     "dotenv": "^16.5.0",
-    "ejs": "^3.1.9",
+    "ejs": "^3.1.10",
     "express": "^5.1.0",
     "express-session": "^1.18.1",
     "node-cron": "^4.0.7",

--- a/routes/adminRoutes.js
+++ b/routes/adminRoutes.js
@@ -17,8 +17,8 @@ router.get('/invitations', async (req, res) => {
         // app.set('views', path.join(__dirname, 'views'));
         res.render('admin_invitations', { 
             invitations: invitations,
-            user: req.user, // Pass user for layout/nav if needed
-            pageTitle: "Admin - Manage Invitations" 
+            // user: req.user, // user is now in res.locals
+            pageTitle: "Admin - Invitations" 
         });
     } catch (error) {
         console.error("Error rendering admin invitations page:", error);

--- a/routes/scheduleRoutes.js
+++ b/routes/scheduleRoutes.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const router = express.Router();
+const ejs = require('ejs'); // Added EJS
+const path = require('path'); // Added Path
 const { isAuthenticated } = require('../middleware/authMiddleware'); // Assuming isAdmin is not strictly needed for user's own schedules
 const scheduleController = require('../controllers/scheduleController');
 const db = require('../db/database'); // For fetching managed rules for the form
@@ -8,27 +10,34 @@ const db = require('../db/database'); // For fetching managed rules for the form
 router.use(isAuthenticated);
 
 // GET /schedules - List all schedules for the logged-in user
-router.get('/', async (req, res) => {
+router.get('/', async (req, res, next) => { // Added next
     try {
-        const schedules = await scheduleController.listSchedulesForUser(req, res);
-        const managedRules = await db.getAllManagedRulesForUser({ userId: req.user.id });
-        
-        // Handle flash messages if connect-flash is integrated
-        // const messages = req.flash(); // Example: { error: ['Msg 1'], success: ['Msg 2'] }
+        // Data fetching remains the same
+        const schedulesFromController = await scheduleController.listSchedulesForUser(req, res); // Renamed to avoid conflict
+        const managedRulesFromDb = await db.getAllManagedRulesForUser({ userId: req.user.id }); // Renamed
 
-        res.render('schedules', {
+        const pageData = {
             pageTitle: 'Manage Schedules',
-            user: req.user,
-            schedules: schedules,
-            managedRules: managedRules, // For the "Add Schedule" form dropdown
-            currentPath: '/schedules',
-            messages: {} // Replace with actual flash messages if implemented
-            // queryMessages: { error: req.query.error, success: req.query.success } // If using query params
+            schedules: schedulesFromController,
+            managedRules: managedRulesFromDb
+            // user, currentPath, messages, queryMessages are in res.locals or handled by sessionFlashMessages
+        };
+        
+        const contentHtml = await ejs.renderFile(
+            path.join(req.app.get('views'), 'schedules.ejs'),
+            { ...pageData, ...res.locals },
+            { async: true }
+        );
+        res.render('layout', {
+            pageTitle: pageData.pageTitle,
+            body: contentHtml
         });
     } catch (error) {
-        console.error("Error rendering schedules page:", error);
-        // req.flash('error', 'Could not load schedules page.');
-        res.redirect('/'); // Or render a generic error page
+        console.error("Error in GET /schedules (controller logic or rendering):", error);
+        // req.flash('error', 'Could not load schedules page.'); // req.flash not reliable
+        req.session.flashMessages = { type: 'error', message: 'Could not load schedules page.' };
+        // res.redirect('/'); // Redirecting here might be problematic.
+        next(error); // Propagate error
     }
 });
 

--- a/routes/uiRoutes.js
+++ b/routes/uiRoutes.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const router = express.Router();
+const ejs = require('ejs'); // Added EJS
+const path = require('path'); // Added Path
 const { isAuthenticated } = require('../middleware/authMiddleware');
 const OpnsenseService = require('../services/opnsenseService'); // Assuming OpnsenseService is default export
 const db = require('../db/database'); // Access all DB functions via this
@@ -20,10 +22,10 @@ function getOpnsenseServiceInstance() {
 }
 
 // GET / - Home/Index page
-router.get('/', (req, res) => {
-    const queryMessages = {};
-    if (req.query.error) queryMessages.error = req.query.error;
-    if (req.query.message) queryMessages.message = req.query.message;
+router.get('/', async (req, res, next) => { // Made async and added next
+    // const queryMessages = {}; // queryMessages are now in res.locals
+    // if (req.query.error) queryMessages.error = req.query.error;
+    // if (req.query.message) queryMessages.message = req.query.message;
 
     if (req.query.invitation_code) {
         req.session.invitationCode = req.query.invitation_code;
@@ -31,51 +33,59 @@ router.get('/', (req, res) => {
         return res.redirect('/'); // Redirect to clean the URL
     }
 
-    if (req.isAuthenticated()) {
-        // If authenticated, and was trying to use an invitation, clear it now it's "seen"
-        // The actual use of invitation happens at registration/first login in authService.js
-        // if (req.session.invitationCode) { 
-        //     // We might not want to clear it here, but rather after successful registration/link.
-        //     // For now, let's assume authService handles clearing it post-registration.
-        // }
-        return res.render('index', { 
-            user: req.user, 
-            invitationCode: req.session.invitationCode, // Pass to template if needed
-            queryMessages,
-            currentPath: '/'
+    const pageData = {
+        pageTitle: 'Welcome - OPNsense Rule Controller',
+        invitationCode: req.session.invitationCode
+        // user and queryMessages are in res.locals
+    };
+
+    try {
+        const contentHtml = await ejs.renderFile(
+            path.join(req.app.get('views'), 'index.ejs'),
+            { ...pageData, ...res.locals }, // Pass pageData and existing res.locals
+            { async: true }
+        );
+        res.render('layout', {
+            pageTitle: pageData.pageTitle,
+            body: contentHtml
         });
-    } else {
-        // Not authenticated
-        return res.render('index', { 
-            user: null, 
-            invitationCode: req.session.invitationCode,
-            queryMessages,
-            currentPath: '/'
-        });
+    } catch (err) {
+        console.error(`Error rendering page index.ejs or layout:`, err);
+        next(err);
     }
 });
 
 // GET /login - Render login page
-router.get('/login', (req, res) => {
-    const queryMessages = {};
-    if (req.query.error) queryMessages.error = req.query.error;
-    if (req.query.message) queryMessages.message = req.query.message;
+router.get('/login', async (req, res, next) => { // Made async and added next
+    // const queryMessages = {}; // queryMessages are now in res.locals
+    // if (req.query.error) queryMessages.error = req.query.error;
+    // if (req.query.message) queryMessages.message = req.query.message;
     
-    // Pass any specific messages for the login page, e.g., from auth failures
-    // req.flash() messages are not set up yet, so using query params for now.
-    res.render('login', { 
-        user: null, 
-        currentPath: '/login',
-        messages: req.session.messages || [], // Placeholder for connect-flash
-        queryMessages // Pass query-based messages
-    });
-    req.session.messages = []; // Clear messages after displaying
+    const pageData = {
+        pageTitle: 'Login - OPNsense Rule Controller'
+        // user, currentPath, messages, queryMessages are in res.locals or handled by sessionFlashMessages
+    };
+
+    try {
+        const contentHtml = await ejs.renderFile(
+            path.join(req.app.get('views'), 'login.ejs'),
+            { ...pageData, ...res.locals },
+            { async: true }
+        );
+        res.render('layout', {
+            pageTitle: pageData.pageTitle,
+            body: contentHtml
+        });
+    } catch (err) {
+        console.error(`Error rendering page login.ejs or layout:`, err);
+        next(err);
+    }
 });
 
 
 // GET /rules - Display managed rules and fetched OPNsense rules
-router.get('/rules', isAuthenticated, async (req, res) => {
-    const userId = req.user.id;
+router.get('/rules', isAuthenticated, async (req, res, next) => { // Added next
+    const userId = req.user.id; // Still needed for DB query
     let managedRulesWithStatus = [];
     let fetchedOpnsenseRules = req.session.fetchedOpnsenseRules || null; // Get from session if previously fetched
     let vlanFilterValue = req.session.vlanFilterValue || ''; // Persist filter value
@@ -139,18 +149,31 @@ router.get('/rules', isAuthenticated, async (req, res) => {
             req.flash('warning', 'OPNsense API not configured. Displaying stored data only.');
         }
         
-        res.render('rules', {
-            user: req.user,
+        const pageData = {
+            pageTitle: 'Manage Firewall Rules',
             managedRules: managedRulesWithStatus,
             fetchedOpnsenseRules: fetchedOpnsenseRules, // From session or null
             vlanFilterValue: vlanFilterValue, // For the input field
-            currentPath: '/rules',
-            messages: req.flash ? req.flash() : {} // For connect-flash if used
+            // user, currentPath, messages are in res.locals or handled by sessionFlashMessages
+        };
+
+        const contentHtml = await ejs.renderFile(
+            path.join(req.app.get('views'), 'rules.ejs'),
+            { ...pageData, ...res.locals },
+            { async: true }
+        );
+        res.render('layout', {
+            pageTitle: pageData.pageTitle,
+            body: contentHtml
         });
-    } catch (error) {
-        console.error("Error in GET /rules:", error);
-        req.flash('error', 'Failed to load rule management page.');
-        res.redirect('/'); // Or render an error page
+        // Removed original catch block as the new pattern has its own.
+    } catch (error) { // This catch is for the outer try-catch block including DB operations
+        console.error("Error in GET /rules (controller logic):", error);
+        // req.flash is not reliable if not setup, use sessionFlashMessages
+        req.session.flashMessages = { type: 'error', message: 'Failed to load rule management page.' };
+        // res.redirect('/'); // Redirecting here might be problematic if headers already sent by error in renderFile.
+                           // The new pattern's next(err) should handle it better.
+        next(error); // Propagate error to Express error handler
     }
 });
 

--- a/routes/userAuthRoutes.js
+++ b/routes/userAuthRoutes.js
@@ -1,32 +1,57 @@
 const express = require('express');
 const router = express.Router();
+const ejs = require('ejs'); // Added EJS
+const path = require('path'); // Added Path
 const passport = require('passport'); // For Google linking
 const authService = require('../services/authService');
 const { isAuthenticated } = require('../middleware/authMiddleware'); // To protect linking routes
 
 // GET /login - Display login page
-router.get('/login', (req, res) => {
-    // The 'is_google_oauth_configured' variable should be available from res.locals if set by app.js middleware
-    // If not, it needs to be explicitly fetched or passed.
-    // For now, assume it's available or views handle its absence.
-    res.render('login', { 
-        pageTitle: 'Login',
-        // Pass any necessary variables for the login.ejs template,
-        // like is_google_oauth_configured, which is used in the template.
-        // These are typically set globally in app.js for all views.
-        // We can rely on res.locals set by the context processor in app.js
-    });
+router.get('/login', async (req, res, next) => { // Made async and added next
+    const pageData = {
+        pageTitle: 'Login - OPNsense Rule Controller'
+        // Other necessary variables for login.ejs are expected to be in res.locals
+    };
+
+    try {
+        const contentHtml = await ejs.renderFile(
+            path.join(req.app.get('views'), 'login.ejs'),
+            { ...pageData, ...res.locals },
+            { async: true }
+        );
+        res.render('layout', {
+            pageTitle: pageData.pageTitle,
+            body: contentHtml
+        });
+    } catch (err) {
+        console.error(`Error rendering page login.ejs or layout:`, err);
+        next(err);
+    }
 });
 
 // GET /register - Display registration page
-router.get('/register', (req, res) => {
-    res.render('register', { 
-        pageTitle: 'Register',
-        // Pass any necessary variables for the register.ejs template
-        // For example, if you want to pass back input values on validation error:
-        // input: req.session.input || {} // Clear after use if needed
-    });
+router.get('/register', async (req, res, next) => { // Made async and added next
+    const pageData = {
+        pageTitle: 'Register - OPNsense Rule Controller'
+        // input data for prefill should be passed in pageData if needed, e.g.,
+        // input: req.session.input || {}
+    };
     // if (req.session.input) delete req.session.input; // Example cleanup
+
+    try {
+        const contentHtml = await ejs.renderFile(
+            path.join(req.app.get('views'), 'register.ejs'),
+            { ...pageData, ...res.locals },
+            { async: true }
+        );
+        res.render('layout', {
+            pageTitle: pageData.pageTitle,
+            body: contentHtml
+        });
+    } catch (err) {
+        console.error(`Error rendering page register.ejs or layout:`, err);
+        next(err);
+    }
 });
 
 // POST /register - User registration

--- a/tests/views.test.js
+++ b/tests/views.test.js
@@ -1,0 +1,82 @@
+const ejs = require('ejs');
+const fs = require('fs');
+const path = require('path');
+
+// List of EJS files to test for compilability
+const filesToTest = [
+    'views/login.ejs',
+    'views/admin_invitations.ejs',
+    'views/admin_settings.ejs',
+    'views/index.ejs',
+    'views/layout.ejs',
+    'views/register.ejs',
+    'views/rules.ejs',
+    'views/schedules.ejs',
+    'views/setup.ejs',
+    'views/partials/_navbar.ejs',
+    'views/partials/_flash_messages.ejs',
+    'views/partials/_config_status.ejs',
+    'views/partials/_footer.ejs'
+];
+
+describe('EJS Template Compilation Tests', () => {
+    filesToTest.forEach(filePath => {
+        it(`should compile ${filePath} without syntax errors`, () => {
+            const templatePath = path.join(__dirname, '..', filePath); // Adjust path to be relative to project root
+            const templateContent = fs.readFileSync(templatePath, 'utf-8');
+            
+            // Attempt to compile the template
+            // If there's a syntax error, ejs.compile will throw an exception
+            expect(() => {
+                ejs.compile(templateContent, { client: true, filename: templatePath });
+            }).not.toThrow();
+        });
+    });
+});
+
+describe('EJS Layout Rendering Test', () => {
+    it('should render layout.ejs with mock data without errors', () => {
+        const layoutPath = path.join(__dirname, '..', 'views/layout.ejs');
+        const layoutContent = fs.readFileSync(layoutPath, 'utf-8');
+        
+        const mockLayoutData = {
+            body: '<div>Mocked page body content for layout test</div>',
+            pageTitle: 'Mock Page Title for Layout',
+            user: { displayName: 'Test User', email: 'test@example.com', is_admin: false }, // Added is_admin for _navbar
+            currentPath: '/mock-path',
+            is_app_secret_key_configured: true,
+            is_opnsense_fully_configured: true,
+            is_google_oauth_configured: true,
+            queryMessages: { message: 'Test query message' }, // This is now a global, but layout/partials might still check for it if not properly removed from their logic
+            sessionFlashMessages: { type: 'success', message: 'Test session flash' },
+            // For _config_status.ejs, these are expected to be boolean
+            // and they are already provided above.
+            
+            // For _flash_messages.ejs, it checks for sessionFlashMessages.type and sessionFlashMessages.message
+            // and also queryMessages.error, queryMessages.success, queryMessages.info
+            // The current mockLayoutData covers sessionFlashMessages.
+            // queryMessages.message is covered. Let's ensure error/success/info are also handled or not expected.
+            // The provided mock queryMessages has a 'message' field.
+            // If _flash_messages directly accesses queryMessages.error etc., they might need to be in mockLayoutData.
+            // Given the current structure, res.locals.queryMessages is expected.
+            // The test will tell if specific sub-fields of queryMessages are needed by _flash_messages if not handled by the global.
+        };
+
+        let renderedHtml = '';
+        expect(() => {
+            // Pass res.locals structure expected by partials if they are not getting it from a global context in test
+            // For this test, mockLayoutData itself serves as the data object for ejs.render.
+            // If partials directly access res.locals.someValue, then mockLayoutData needs to have 'someValue'.
+            renderedHtml = ejs.render(layoutContent, mockLayoutData, { filename: layoutPath });
+        }).not.toThrow();
+
+        // Optional: Check if body and title are in the rendered output
+        expect(renderedHtml).toContain('<div>Mocked page body content for layout test</div>');
+        expect(renderedHtml).toContain('<title>Mock Page Title for Layout</title>');
+        // Optional: Check for content from a partial, if easy
+        expect(renderedHtml).toContain('Test User'); // Assuming navbar shows user.displayName
+        expect(renderedHtml).toContain('Test session flash'); // From _flash_messages
+        // Using regex for _config_status.ejs to be more robust against whitespace variations:
+        expect(renderedHtml).toMatch(/OPNsense API:\s*<span style="color: green;">Configured<\/span>/);
+    });
+});

--- a/views/admin_invitations.ejs
+++ b/views/admin_invitations.ejs
@@ -20,7 +20,7 @@
     </style>
 </head>
 <body>
-    <% include partials/navbar { user: user } %> <!-- Assuming a navbar partial -->
+    <%- include('partials/_navbar') %> <!-- Assuming a navbar partial -->
 
     <h1>Admin: Manage Invitation Codes</h1>
 

--- a/views/admin_settings.ejs
+++ b/views/admin_settings.ejs
@@ -1,4 +1,4 @@
-<% include partials/_navbar { currentPath: '/admin/settings' } %>
+<%- include('partials/_navbar') %>
 
 <div class="container mt-4">
     <div class="row">
@@ -8,7 +8,7 @@
                 Manage core application settings here. Be cautious when changing these values, especially secrets.
             </p>
 
-            <% include partials/_flash_messages {} %>
+            <%- include('partials/_flash_messages') %>
             <% if (typeof queryMessages !== 'undefined' && queryMessages.error) { %>
                 <div class="alert alert-danger"><%= queryMessages.error %></div>
             <% } %>
@@ -121,5 +121,5 @@
     </div>
 </div>
 
-<% include partials/_footer {} %>
+<%- include('partials/_footer') %>
 <%# /* vim: set ft=html : */ %>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,10 +1,3 @@
-<% include layout { 
-    pageTitle: 'Welcome - OPNsense Rule Controller', 
-    user: typeof user !== 'undefined' ? user : null, 
-    currentPath: '/',
-    messages: typeof messages !== 'undefined' ? messages : {},
-    queryMessages: typeof queryMessages !== 'undefined' ? queryMessages : {}
-} %>
 
         <div class="index-container" style="text-align: center; padding: 40px 20px;">
             <h1>Welcome to the OPNsense Rule Controller</h1>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -32,22 +32,18 @@
 </head>
 <body>
     <header>
-        <% include partials/_navbar { user: typeof user !== 'undefined' ? user : null, currentPath: typeof currentPath !== 'undefined' ? currentPath : '/' } %>
+        <%- include('partials/_navbar') %>
     </header>
 
     <div class="container">
-        <% include partials/_flash_messages { messages: typeof messages !== 'undefined' ? messages : {} } %>
+        <%- include('partials/_flash_messages') %>
         <%- body %>
     </div>
 
     <footer>
         <p>&copy; <%= new Date().getFullYear() %> OPNsense Rule Controller</p>
         <!-- You can add the config status partial here if desired -->
-        <% include partials/_config_status {
-            is_app_secret_key_configured: typeof is_app_secret_key_configured !== 'undefined' ? is_app_secret_key_configured : false,
-            is_opnsense_fully_configured: typeof is_opnsense_fully_configured !== 'undefined' ? is_opnsense_fully_configured : false,
-            is_google_oauth_configured: typeof is_google_oauth_configured !== 'undefined' ? is_google_oauth_configured : false
-        } %>
+        <%- include('partials/_config_status') %>
     </footer>
 </body>
 </html>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,9 +1,3 @@
-<% include layout { 
-    pageTitle: 'Login - OPNsense Rule Controller', 
-    user: typeof user !== 'undefined' ? user : null, 
-    currentPath: '/auth/login', // Updated currentPath
-    // sessionFlashMessages is available globally via app.locals or context processor in app.js
-} %>
 
         <div class="auth-container">
             <h2>Login</h2>
@@ -40,11 +34,7 @@
             <hr style="margin-top: 30px; margin-bottom: 20px;">
             <h4>Configuration Status Overview:</h4>
             <p><small>This section is for diagnostic purposes.</small></p>
-            <% include('partials/_config_status', {
-                is_app_secret_key_configured: typeof is_app_secret_key_configured !== 'undefined' ? is_app_secret_key_configured : false,
-                is_opnsense_fully_configured: typeof is_opnsense_fully_configured !== 'undefined' ? is_opnsense_fully_configured : false,
-                is_google_oauth_configured: typeof is_google_oauth_configured !== 'undefined' ? is_google_oauth_configured : false
-            }) %>
+            <%- include('partials/_config_status') %>
         </div>
         <style>
             .auth-container { text-align: center; max-width: 400px; margin: 30px auto; padding: 20px; border: 1px solid #ddd; border-radius: 8px; background-color: #fff; box-shadow: 0 0 10px rgba(0,0,0,0.05); }

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -1,8 +1,3 @@
-<% include layout { 
-    pageTitle: 'Register - OPNsense Rule Controller', 
-    user: typeof user !== 'undefined' ? user : null, 
-    currentPath: '/auth/register'
-} %>
 
         <div class="auth-container">
             <h2>Register</h2>

--- a/views/rules.ejs
+++ b/views/rules.ejs
@@ -1,10 +1,3 @@
-<% include layout { 
-    pageTitle: 'Manage Firewall Rules', 
-    user: typeof user !== 'undefined' ? user : null, 
-    currentPath: '/rules',
-    messages: typeof messages !== 'undefined' ? messages : {},
-    queryMessages: typeof queryMessages !== 'undefined' ? queryMessages : {}
-} %>
 
         <div class="rules-container">
             <h2>OPNsense Firewall Rule Management</h2>

--- a/views/schedules.ejs
+++ b/views/schedules.ejs
@@ -1,10 +1,3 @@
-<% include layout { 
-    pageTitle: pageTitle || 'Manage Schedules', 
-    user: user, 
-    currentPath: currentPath,
-    messages: messages, // Assuming messages are passed from the route
-    queryMessages: queryMessages // Assuming queryMessages are passed
-} %>
 
         <div class="schedules-container">
             <h2>Rule Schedules</h2>

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -1,4 +1,4 @@
-<% include partials/_navbar { currentPath: '/setup' } %>
+<%- include('partials/_navbar') %>
 
 <div class="container mt-4">
     <h1>Initial Application Setup</h1>
@@ -8,7 +8,7 @@
         but this setup process will help you initialize them.
     </p>
 
-    <% include partials/_flash_messages {} %>
+    <%- include('partials/_flash_messages') %>
     <% if (typeof queryMessages !== 'undefined' && queryMessages.error) { %>
         <div class="alert alert-danger"><%= queryMessages.error %></div>
     <% } %>
@@ -93,5 +93,5 @@
     </form>
 </div>
 
-<% include partials/_footer {} %>
+<%- include('partials/_footer') %>
 <%# /* vim: set ft=html : */ %>


### PR DESCRIPTION
This commit addresses an issue where EJS templates were not correctly using the main layout file, leading to "body is not defined" errors. The primary change involves modifying route handlers to manually render content views to HTML strings and pass them as a 'body' variable to the main 'layout.ejs' template.

Key changes:

- Removed incorrect `<%- include('layout') %>` directives from top-level content views (e.g., index.ejs, login.ejs).
- Updated route handlers and relevant controller methods to:
    1. Use `ejs.renderFile()` to render the specific page content to an HTML string.
    2. Pass this HTML string as a `body` variable when rendering `layout.ejs`.
    3. Ensure `pageTitle` and other necessary data are passed correctly.
- Confirmed that `admin_invitations.ejs` is treated as a standalone page and is not wrapped by the main layout.
- Updated EJS tests in `tests/views.test.js` to include a render test for `layout.ejs` with mocked data, ensuring it can process the `body` variable and other global data.

This is intended to allow for manual testing of the layout and rendering corrections in a live environment.