### PR TITLE
Fix: Correct 'Fetch OPNsense rules' method and resolve DB schema error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ NODE_ENV=development # Set to 'production' for production
 # OPNSENSE_BASE_URL=https://your-opnsense-router-ip-or-hostname/api
 # OPNSENSE_API_KEY=your_opnsense_api_key
 # OPNSENSE_API_SECRET=your_opnsense_api_secret
+# OPNSENSE_IGNORE_CERT_ERRORS="false" # Set to "true" to disable SSL certificate validation for OPNsense API calls. WARNING: Insecure, for development/testing only.
 
 # Google OAuth Configuration
 GOOGLE_CLIENT_ID="YOUR_GOOGLE_CLIENT_ID_HERE.apps.googleusercontent.com" # Replace with your actual Client ID

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ cp .env.example .env
         *   `GOOGLE_CLIENT_ID`: Your Google OAuth Client ID.
         *   `GOOGLE_CLIENT_SECRET`: Your Google OAuth Client Secret.
         *   `SESSION_SECRET`: A strong, random string for session security.
+        *   `OPNSENSE_IGNORE_CERT_ERRORS`: Set to `"true"` to disable SSL certificate validation for OPNsense API calls. **WARNING:** This is insecure and should only be used for development or testing with self-signed certificates. Defaults to `"false"`.
 
 ### In-Application Configuration & Out-of-Box Experience (OOBE)
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS Schedules (
     cron_expression TEXT NOT NULL,
     action_type TEXT NOT NULL, 
     action_params TEXT, 
-    is_active BOOLEAN DEFAULT TRUE,
+    is_enabled BOOLEAN DEFAULT TRUE,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     last_triggered_at DATETIME DEFAULT NULL, -- Added based on updateScheduleLastTriggered
@@ -100,7 +100,7 @@ CREATE TABLE IF NOT EXISTS JobRuns (
 -- Indexes for performance
 CREATE INDEX IF NOT EXISTS idx_users_email ON Users(email);
 CREATE INDEX IF NOT EXISTS idx_users_google_id ON Users(google_id);
-CREATE INDEX IF NOT EXISTS idx_schedules_is_active ON Schedules(is_active);
+CREATE INDEX IF NOT EXISTS idx_schedules_is_enabled ON Schedules(is_enabled);
 CREATE INDEX IF NOT EXISTS idx_jobruns_schedule_id ON JobRuns(schedule_id);
 CREATE INDEX IF NOT EXISTS idx_jobruns_status ON JobRuns(status);
 CREATE INDEX IF NOT EXISTS idx_jobruns_run_at ON JobRuns(run_at);

--- a/routes/uiRoutes.js
+++ b/routes/uiRoutes.js
@@ -177,9 +177,9 @@ router.get('/rules', isAuthenticated, async (req, res, next) => { // Added next
     }
 });
 
-// POST /rules/fetch-opnsense - Fetch rules from OPNsense
-router.post('/rules/fetch-opnsense', isAuthenticated, async (req, res) => {
-    const vlanFilter = req.body.vlanFilter || null;
+// GET /rules/fetch-opnsense - Fetch rules from OPNsense
+router.get('/rules/fetch-opnsense', isAuthenticated, async (req, res) => {
+    const vlanFilter = req.query.vlanFilter || null;
     const opnsenseService = getOpnsenseServiceInstance();
 
     if (!opnsenseService) {

--- a/services/opnsenseService.js
+++ b/services/opnsenseService.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const https = require('https'); // Added https module
 
 class OpnsenseService {
     constructor(baseURL, apiKey, apiSecret) {
@@ -16,6 +17,15 @@ class OpnsenseService {
             },
             timeout: 5000, // 5 seconds
         });
+
+        // Check if SSL certificate validation should be ignored
+        if (process.env.OPNSENSE_IGNORE_CERT_ERRORS === 'true' || process.env.OPNSENSE_IGNORE_CERT_ERRORS === '1') {
+            const httpsAgent = new https.Agent({
+                rejectUnauthorized: false
+            });
+            this.client.defaults.httpsAgent = httpsAgent;
+            console.log('OpnsenseService: SSL certificate validation is DISABLED due to OPNSENSE_IGNORE_CERT_ERRORS environment variable.');
+        }
     }
 
     /**

--- a/views/rules.ejs
+++ b/views/rules.ejs
@@ -17,7 +17,7 @@
 
             <section id="fetch-opnsense-rules">
                 <h3>Fetch Rules from OPNsense</h3>
-                <form action="/rules/fetch-opnsense" method="POST" class="form-inline">
+                <form action="/rules/fetch-opnsense" method="GET" class="form-inline">
                     <div class="form-group">
                         <label for="vlanFilter">Filter by Interface/VLAN (optional):</label>
                         <input type="text" name="vlanFilter" id="vlanFilter" placeholder="e.g., vlan02, igb1, LAN" value="<%= typeof vlanFilterValue !== 'undefined' ? vlanFilterValue : '' %>">


### PR DESCRIPTION
This commit addresses two main issues and introduces a development utility:

1.  **Fix 'Cannot GET /rules/fetch-opnsense'**:
    - I changed the `/rules/fetch-opnsense` route from POST to GET in `routes/uiRoutes.js`.
    - I updated the corresponding form in `views/rules.ejs` to use the GET method.
    - I ensured `vlanFilter` is correctly passed as a query parameter.

2.  **Fix 'SqliteError: no such column: s.is_enabled'**:
    - I corrected the `Schedules` table schema in `db/schema.sql`. The column `is_active` was renamed to `is_enabled` to match its usage in `db/database.js` functions (`getAllActiveSchedules`, `addSchedule`, etc.).
    - I renamed the corresponding index `idx_schedules_is_active` to `idx_schedules_is_enabled`.
    - I provided migration SQL for existing databases: ```sql ALTER TABLE Schedules RENAME COLUMN is_active TO is_enabled; DROP INDEX IF EXISTS idx_schedules_is_active; CREATE INDEX IF NOT EXISTS idx_schedules_is_enabled ON Schedules(is_enabled); ```

3.  **Add configurable SSL certificate validation for OPNsense**:
    - I introduced the `OPNSENSE_IGNORE_CERT_ERRORS` environment variable.
    - If set to "true" or "1", SSL certificate validation will be disabled for OPNsense API calls in `services/opnsenseService.js`. This is intended for development/testing with self-signed or expired certificates and is insecure for production.
    - I updated `.env.example` to document this new variable and its risks.